### PR TITLE
Add meta tags to enable ‘mobile web app’ mode.

### DIFF
--- a/views/watch.jade
+++ b/views/watch.jade
@@ -17,7 +17,11 @@ html(lang='en')
 		link(rel='stylesheet', href='/css/fonts.css')
 		link(rel='stylesheet', href='/css/sidebar.css')
 		link(rel='stylesheet', href='/css/watch.css')
-	
+		meta(name='mobile-web-app-capable', content='yes')
+		meta(name='apple-mobile-web-app-capable', content='yes')
+		meta(name='apple-mobile-web-app-status-bar-style', content='black')
+		meta(name='apple-mobile-web-app-title', content='#{event} Captions')
+
 	body(ng-app='Aloft', ng-controller='AloftController' ng-style="{'backgroundColor': bgColor}")
 		.status-bar.connected
 		header.nav-down


### PR DESCRIPTION
This allows for users to add the website to their mobile device’s home screen and then launch it without the address bar or other functionality/UI of a typical web browser. This makes it easier to display captions without any unnecessary application chrome around them.

Navigating to an aloft.nu URL in a browser will continue to work as expected. This behavior is only available when the URL is saved to the device’s home screen and launched as though it is a standalone web app.